### PR TITLE
Add Get permission to Integration and ObjectType Create action

### DIFF
--- a/aws-customerprofiles-integration/aws-customerprofiles-integration.json
+++ b/aws-customerprofiles-integration/aws-customerprofiles-integration.json
@@ -69,6 +69,7 @@
   "handlers": {
     "create": {
       "permissions": [
+        "profile:GetIntegration",
         "profile:PutIntegration"
       ]
     },

--- a/aws-customerprofiles-objecttype/aws-customerprofiles-objecttype.json
+++ b/aws-customerprofiles-objecttype/aws-customerprofiles-objecttype.json
@@ -208,6 +208,7 @@
   "handlers": {
     "create": {
       "permissions": [
+        "profile:GetProfileObjectType",
         "profile:PutProfileObjectType"
       ]
     },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add Get permission to Integration and ObjectType Create action. 
Because in the implementation of CreateHandler of these 2 resource, will first check if the resource already existed or not using Get call to avoid the Update situation. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
