### PR TITLE
Mark ObjectTypeName and DefaultExpirationDays as required

### DIFF
--- a/aws-customerprofiles-domain/aws-customerprofiles-domain.json
+++ b/aws-customerprofiles-domain/aws-customerprofiles-domain.json
@@ -397,7 +397,8 @@
   },
   "additionalProperties": false,
   "required": [
-    "DomainName"
+    "DomainName",
+    "DefaultExpirationDays"
   ],
   "tagging": {
     "taggable": true,

--- a/aws-customerprofiles-objecttype/aws-customerprofiles-objecttype.json
+++ b/aws-customerprofiles-objecttype/aws-customerprofiles-objecttype.json
@@ -209,7 +209,9 @@
   },
   "additionalProperties": false,
   "required": [
-    "DomainName"
+    "DomainName",
+    "ObjectTypeName",
+    "Description"
   ],
   "tagging": {
     "taggable": true,


### PR DESCRIPTION
This change is to keep this repo in sync with changes made internally. Marks ObjectTypeName, Description as required in AWS::CustomerProfiles::ObjectType and DefaultExpirationDays as required in AWS::CustomerProfiles::Domain